### PR TITLE
Add full path for kill command in systemd service file

### DIFF
--- a/site-template/cf.service.in
+++ b/site-template/cf.service.in
@@ -11,7 +11,7 @@ Requires=elasticsearch.service
 ExecStart=_JAVAPATH_/java _JAVAOPTS_ -jar _CFPATH_/_CHANNELFINDER_JAR_NAME_
 SuccessExitStatus=143 
 
-ExecReload=kill -SIGINT $MAINPID
+ExecReload=/usr/bin/kill -SIGINT $MAINPID
 KillMode=process
 
 Restart=on-failure


### PR DESCRIPTION
systemd seems to like full paths

```
systemd[1]: [/etc/systemd/system/channelfinder.service:14] Executable path is not absolute, ignoring: kill -SIGINT $MAINPID
```